### PR TITLE
addClaimed added

### DIFF
--- a/smoltingpot.sol
+++ b/smoltingpot.sol
@@ -653,7 +653,8 @@ contract SmolTingPot is Ownable {
         uint256 pendingWithBooster = pending.mul(Museum.getBoosterForUser(msg.sender, _pid).add(1));
         if (pendingWithBooster > 0) {
 		Ting.mint(treasuryAddr, pendingWithBooster.div(40)); // 2.5% TING for the treasury (usable to purchase NFTs)
-        	Ting.mint(msg.sender, pendingWithBooster);							
+        	Ting.mint(msg.sender, pendingWithBooster);	
+		Ting.addClaimed(pendingWithBooster);
 	    }
 	    
         pool.token.transferFrom(address(msg.sender), address(this), _amount);
@@ -689,6 +690,7 @@ contract SmolTingPot is Ownable {
         {
             Ting.mint(treasuryAddr, pendingWithBooster.div(40)); 
             Ting.mint(staker, pendingWithBooster);
+	    Ting.addClaimed(pendingWithBooster);
         }
 
         pool.token.transfer(address(staker), _amount);

--- a/smoltingpot.sol
+++ b/smoltingpot.sol
@@ -593,8 +593,8 @@ contract SmolTingPot is Ownable {
     function setTingsPerDay(uint256 pid, uint256 amount) public onlyOwner {
         require(amount >= 0, "hey smol tings per day cannot be negative");
         uint256 blockTime = block.timestamp;
-        uint256 tingReward = blockTime.sub(poolInfo[pid].lastUpdateTime).mul(poolInfo[pid].tingsPerDay).div(86400);
-        poolInfo[pid].accTingPerShare = poolInfo[pid].accTingPerShare.add(tingReward.mul(1e12));
+        uint256 tingReward = blockTime.sub(poolInfo[pid].lastUpdateTime).mul(poolInfo[pid].tingsPerDay.mul(1e12)).div(86400);
+        poolInfo[pid].accTingPerShare = poolInfo[pid].accTingPerShare.add(tingReward);
         poolInfo[pid].lastUpdateTime = block.timestamp;
         poolInfo[pid].tingsPerDay = amount;
     }
@@ -607,8 +607,8 @@ contract SmolTingPot is Ownable {
         uint256 accTing = pool.accTingPerShare;
         uint256 tokenSupply = pool.token.balanceOf(address(this));
         if (blockTime > pool.lastUpdateTime && tokenSupply != 0) {
-            uint256 tingReward = blockTime.sub(pool.lastUpdateTime).mul(pool.tingsPerDay).div(86400);
-            accTing = accTing.add(tingReward.mul(1e12));					// reward Clock at t time
+            uint256 tingReward = blockTime.sub(pool.lastUpdateTime).mul(pool.tingsPerDay.mul(1e12)).div(86400);
+            accTing = accTing.add(tingReward);					// reward Clock at t time
         }
         uint256 pending = user.amount.mul(accTing).div(1e12).sub(user.rewardDebt);
         if (Museum.getBoosterForUser(_user, _pid) > 0) pending = pending.mul(Museum.getBoosterForUser(_user, _pid).add(1));
@@ -643,8 +643,8 @@ contract SmolTingPot is Ownable {
         require(_amount.add(user.amount) <= pool.maxStake, "cannot stake beyond max stake value");
         uint256 blockTime = block.timestamp;
 	    uint256 accTing = pool.accTingPerShare;
-        uint256 tingReward = blockTime.sub(pool.lastUpdateTime).mul(pool.tingsPerDay).div(86400); 
-        accTing = accTing.add(tingReward.mul(1e12));					// HERE : no update of the pool before, so you compute the real amount of accTingPerShare to use it to mint
+        uint256 tingReward = blockTime.sub(pool.lastUpdateTime).mul(pool.tingsPerDay.mul(1e12)).div(86400); 
+        accTing = accTing.add(tingReward);					// HERE : no update of the pool before, so you compute the real amount of accTingPerShare to use it to mint
 
         uint256 pending = user.amount.mul(accTing).div(1e12).sub(user.rewardDebt);
         user.amount = user.amount.add(_amount);


### PR DESCRIPTION
When a user harvest his pending Tings, it updates the claimed Tings in SmolTing so we can display the total number of Tings already claimed by all users.
Increase a little bit the amount of gas for people claiming Tings, though. But Museum is doing the exact same thing so I think it's a nice feature to monitor total emission